### PR TITLE
minor changes to the web site

### DIFF
--- a/src/doc/_includes/modals/download.html
+++ b/src/doc/_includes/modals/download.html
@@ -11,7 +11,7 @@
       </div>
       <div class="modal-body">
         <a class="btn btn-primary btn-lg btn-block" href="{{ page.relative_path }}assets/fork-awesome-{{ site.forkawesome.version }}.zip">
-          {{ site.forkawesome.name }} {{ site.forkawesome.minor_version }}
+          {{ site.forkawesome.name }} {{ site.forkawesome.version }}
         </a>
         <div class="row margin-bottom-lg margin-top-lg">
           <div class="col-md-12 text-center">

--- a/src/doc/get-started.html
+++ b/src/doc/get-started.html
@@ -45,14 +45,14 @@ relative_path: ../
 <link rel="stylesheet" href="path/to/fork-awesome/css/fork-awesome.min.css">
 {% endhighlight %}
         </li>
-        <li>Check out the <a href="{{ page.relative_path }}examples/">examples</a> to start using Font Awesome!</li>
+        <li>Check out the <a href="{{ page.relative_path }}examples/">examples</a> to start using Fork Awesome!</li>
       </ol>
     </div>
 
     <div class="download-preprocessors" id="download-preprocessors">
       <h3>Using Sass or Less</h3>
 
-      <p>Use this method to customize Font Awesome {{ site.forkawesome.version }} using Less or Sass.</p>
+      <p>Use this method to customize Fork Awesome {{ site.forkawesome.version }} using Less or Sass.</p>
       <ol>
         <li>Copy the <code>fork-awesome/</code> directory into your project.</li>
         <li>
@@ -64,7 +64,7 @@ relative_path: ../
           <p class="alert alert-success"><i class="fa fa-info-circle"></i> The font path is relative from your compiled CSS directory.</p>
         </li>
         <li>Re-compile your Less or Sass if using a static compiler. Otherwise, you should be good to go.</li>
-        <li>Check out the <a href="{{ page.relative_path }}examples/">examples</a> to start using Font Awesome!</li>
+        <li>Check out the <a href="{{ page.relative_path }}examples/">examples</a> to start using Fork Awesome!</li>
       </ol>
     </div>
   </section>
@@ -76,7 +76,7 @@ relative_path: ../
   <div class="row">
     <div class="col-md-6" id="support-validators">
       <h4>Validators</h4>
-      <p>In order to provide the best possible experience to old and buggy browsers, Font Awesome uses <a href="http://browserhacks.com">CSS browser hacks</a> in several places to target special CSS to certain browser versions in order to work around bugs in the browsers themselves. These hacks understandably cause CSS validators to complain that they are invalid. In a couple places, we also use bleeding-edge CSS features that aren't yet fully standardized, but these are used purely for progressive enhancement.</p>
+      <p>In order to provide the best possible experience to old and buggy browsers, Fork Awesome uses <a href="http://browserhacks.com">CSS browser hacks</a> in several places to target special CSS to certain browser versions in order to work around bugs in the browsers themselves. These hacks understandably cause CSS validators to complain that they are invalid. In a couple places, we also use bleeding-edge CSS features that aren't yet fully standardized, but these are used purely for progressive enhancement.</p>
       <p>These validation warnings don't matter in practice since the non-hacky portion of our CSS does fully validate and the hacky portions don't interfere with the proper functioning of the non-hacky portion, hence why we deliberately ignore these particular warnings.</p>
       <p><a href="http://getbootstrap.com/getting-started/#support-validators">Getting started - Validators</a> by <a href="http://getbootstrap.com/about/#team">Bootstrap Team</a> is licensed under <a href="https://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a></p>
     </div>


### PR DESCRIPTION
- show the full version number in the modal download dialog (currently it only shows `1.0`)
- in certain cases the term `Font Awesome` was still used on the `Get Started` page