### PR TITLE
Fix old references to fontawesome in SCSS

### DIFF
--- a/scss/_path.scss
+++ b/scss/_path.scss
@@ -3,13 +3,13 @@
 
 @font-face {
   font-family: '#{$fa-font-family}';
-  src: url('#{$fa-font-path}/fontawesome-webfont.eot?v=#{$fa-version}');
-  src: url('#{$fa-font-path}/fontawesome-webfont.eot?#iefix&v=#{$fa-version}') format('embedded-opentype'),
-    url('#{$fa-font-path}/fontawesome-webfont.woff2?v=#{$fa-version}') format('woff2'),
-    url('#{$fa-font-path}/fontawesome-webfont.woff?v=#{$fa-version}') format('woff'),
-    url('#{$fa-font-path}/fontawesome-webfont.ttf?v=#{$fa-version}') format('truetype'),
-    url('#{$fa-font-path}/fontawesome-webfont.svg?v=#{$fa-version}#fontawesomeregular') format('svg');
-//  src: url('#{$fa-font-path}/FontAwesome.otf') format('opentype'); // used when developing fonts
+  src: url('#{$fa-font-path}/forkawesome-webfont.eot?v=#{$fa-version}');
+  src: url('#{$fa-font-path}/forkawesome-webfont.eot?#iefix&v=#{$fa-version}') format('embedded-opentype'),
+    url('#{$fa-font-path}/forkawesome-webfont.woff2?v=#{$fa-version}') format('woff2'),
+    url('#{$fa-font-path}/forkawesome-webfont.woff?v=#{$fa-version}') format('woff'),
+    url('#{$fa-font-path}/forkawesome-webfont.ttf?v=#{$fa-version}') format('truetype'),
+    url('#{$fa-font-path}/forkawesome-webfont.svg?v=#{$fa-version}#forkawesomeregular') format('svg');
+//  src: url('#{$fa-font-path}/ForkAwesome.otf') format('opentype'); // used when developing fonts
   font-weight: normal;
   font-style: normal;
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -4,10 +4,9 @@
 $fa-font-path:        "../fonts" !default;
 $fa-font-size-base:   14px !default;
 $fa-line-height-base: 1 !default;
-//$fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome//fonts" !default; // for referencing Bootstrap CDN font files directly
-$fa-css-prefix:        !default;
-$fa-font-family:       !default;
-$fa-version:          "" !default;
+$fa-css-prefix:       "fa" !default;
+$fa-font-family:      "ForkAwesome" !default;
+$fa-version:          "1.0.10" !default;
 $fa-border-color:     #eee !default;
 $fa-inverse:          #fff !default;
 $fa-li-width:         (30em / 14) !default;

--- a/src/doc/assets/fork-awesome/scss/_path.scss
+++ b/src/doc/assets/fork-awesome/scss/_path.scss
@@ -3,13 +3,13 @@
 
 @font-face {
   font-family: '#{$fa-font-family}';
-  src: url('#{$fa-font-path}/fontawesome-webfont.eot?v=#{$fa-version}');
-  src: url('#{$fa-font-path}/fontawesome-webfont.eot?#iefix&v=#{$fa-version}') format('embedded-opentype'),
-    url('#{$fa-font-path}/fontawesome-webfont.woff2?v=#{$fa-version}') format('woff2'),
-    url('#{$fa-font-path}/fontawesome-webfont.woff?v=#{$fa-version}') format('woff'),
-    url('#{$fa-font-path}/fontawesome-webfont.ttf?v=#{$fa-version}') format('truetype'),
-    url('#{$fa-font-path}/fontawesome-webfont.svg?v=#{$fa-version}#fontawesomeregular') format('svg');
-//  src: url('#{$fa-font-path}/FontAwesome.otf') format('opentype'); // used when developing fonts
+  src: url('#{$fa-font-path}/forkawesome-webfont.eot?v=#{$fa-version}');
+  src: url('#{$fa-font-path}/forkawesome-webfont.eot?#iefix&v=#{$fa-version}') format('embedded-opentype'),
+    url('#{$fa-font-path}/forkawesome-webfont.woff2?v=#{$fa-version}') format('woff2'),
+    url('#{$fa-font-path}/forkawesome-webfont.woff?v=#{$fa-version}') format('woff'),
+    url('#{$fa-font-path}/forkawesome-webfont.ttf?v=#{$fa-version}') format('truetype'),
+    url('#{$fa-font-path}/forkawesome-webfont.svg?v=#{$fa-version}#forkawesomeregular') format('svg');
+//  src: url('#{$fa-font-path}/ForkAwesome.otf') format('opentype'); // used when developing fonts
   font-weight: normal;
   font-style: normal;
 }

--- a/src/doc/assets/fork-awesome/scss/_variables.scss
+++ b/src/doc/assets/fork-awesome/scss/_variables.scss
@@ -6,10 +6,9 @@
 $fa-font-path:        "../fonts" !default;
 $fa-font-size-base:   14px !default;
 $fa-line-height-base: 1 !default;
-//$fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/{{site.fontawesome.version}}/fonts" !default; // for referencing Bootstrap CDN font files directly
-$fa-css-prefix:       {{ site.fontawesome.css_prefix }} !default;
-$fa-font-family:      {{ site.fontawesome.font_family }} !default;
-$fa-version:          "{{ site.fontawesome.version }}" !default;
+$fa-css-prefix:       "{{ site.forkawesome.css_prefix }}" !default;
+$fa-font-family:      "{{ site.forkawesome.font_family }}" !default;
+$fa-version:          "{{ site.forkawesome.version }}" !default;
 $fa-border-color:     #eee !default;
 $fa-inverse:          #fff !default;
 $fa-li-width:         (30em / 14) !default;


### PR DESCRIPTION
Some old `fontawesome` references were still there in in the `_variables.scss` file, resulting in bad generated SCSS variable values. The `@font-face` definition was also using `fontawesome` in URLs. With those changes, using ForkAwesome with SCSS is now working for me.

Finally, I've taken the liberty to remove the commented line referring to the bootstrapcdn, as it was also using Font Awesome icons.

By the way, thank you for this community fork! :)