### PR TITLE
Fix incorrect version number in site navbar

### DIFF
--- a/src/doc/_includes/navbar.html
+++ b/src/doc/_includes/navbar.html
@@ -33,7 +33,7 @@
           <ul class="dropdown-menu pull-right">
             <li><a href="{{ page.relative_path }}icons/"><i class="fa fa-flag fa-fw" aria-hidden="true"></i>&nbsp; All Icons</a></li>
             <li class="divider"></li>
-            <li><a href="{{ page.relative_path }}icons/#new"><i class="fa fa-handshake-o fa-fw" aria-hidden="true"></i>&nbsp; New Icons in {{ site.fontawesome.minor_version }}</a></li>
+            <li><a href="{{ page.relative_path }}icons/#new"><i class="fa fa-handshake-o fa-fw" aria-hidden="true"></i>&nbsp; New Icons</a></li>
             <li><a href="{{ page.relative_path }}icons/#web-application"><i class="fa fa-camera-retro fa-fw" aria-hidden="true"></i>&nbsp; Web Application Icons</a></li>
             <li><a href="{{ page.relative_path }}icons/#accessibility"><i class="fa fa-universal-access fa-fw" aria-hidden="true"></i>&nbsp; Accessibility Icons</a></li>
             <li><a href="{{ page.relative_path }}icons/#hand"><i class="fa fa-hand-spock-o fa-fw" aria-hidden="true"></i>&nbsp; Hand Icons</a></li>


### PR DESCRIPTION
On the site navbar, under the "Icons" menu, it says "New Icons in 4.7." Fork Awesome is currently at version 1.1.7, so the "4.7" is an error left over from the original Font Awesome site.

This PR removes the version number altogether.