### PR TITLE
Apply changes from #139 to .txt templates

### DIFF
--- a/src/doc/assets/fork-awesome/scss/icons.scss.txt
+++ b/src/doc/assets/fork-awesome/scss/icons.scss.txt
@@ -4,4 +4,4 @@
    readers do not read off random characters that represent icons */
 {% for icon in icons %}{% for alias in icon.aliases %}
 .#{$fa-css-prefix}-{{ alias }}:before,{% endfor %}
-.#{$fa-css-prefix}-{{ icon.id }}:before { content: $fa-var-{{ icon.id }}; }{% endfor %}
+.#{$fa-css-prefix}-{{ icon.id }}:before { content: fa-content($fa-var-{{ icon.id }}); }{% endfor %}

--- a/src/doc/assets/fork-awesome/scss/variables.scss.txt
+++ b/src/doc/assets/fork-awesome/scss/variables.scss.txt
@@ -13,5 +13,5 @@ $fa-border-color:     #eee !default;
 $fa-inverse:          #fff !default;
 $fa-li-width:         (30em / 14) !default;
 
-{% assign sorted_icons = icons | expand_aliases | sort_by:'class' %}{% for icon in sorted_icons %}$fa-var-{{ icon.class }}: "\{{ icon.unicode }}";
+{% assign sorted_icons = icons | expand_aliases | sort_by:'class' %}{% for icon in sorted_icons %}$fa-var-{{ icon.class }}: \{{ icon.unicode }};
 {% endfor %}


### PR DESCRIPTION
Hi @xuv and @eidsonator,

I noticed, that most of my changes (related to #139) were removed in 6a5ed1863dbbc53de1156d7fc2deb9ac01eda1ee.

`scss/_icons.scss` file does not use the `fa-content()` function again, and `scss/_variables.scss` has double quotes around unicode values.

I believe this little change will prevent the issue in the future.

Thank you.