### PR TITLE
Improve the font stack used on the website

### DIFF
--- a/src/doc/assets/less/bootstrap-3.3.5/jumbotron.less
+++ b/src/doc/assets/less/bootstrap-3.3.5/jumbotron.less
@@ -18,7 +18,6 @@
   p {
     margin-bottom: (@jumbotron-padding / 2);
     font-size: @jumbotron-font-size;
-    font-weight: 200;
   }
 
   > hr {

--- a/src/doc/assets/less/bootstrap-3.3.5/type.less
+++ b/src/doc/assets/less/bootstrap-3.3.5/type.less
@@ -62,7 +62,6 @@ p {
 .lead {
   margin-bottom: @line-height-computed;
   font-size: floor((@font-size-base * 1.15));
-  font-weight: 300;
   line-height: 1.4;
 
   @media (min-width: @screen-sm-min) {

--- a/src/doc/assets/less/site/bootstrap/jumbotron.less
+++ b/src/doc/assets/less/site/bootstrap/jumbotron.less
@@ -13,12 +13,10 @@
     margin: 0 0 15px;
   }
   p {
-    font-family: @font-family-alt;
     margin-top: 15px;
     margin-bottom: 15px;
     font-size: 24px;
     line-height: 1.3;
-    font-weight: lighter;
   }
 
   .list-group-item {

--- a/src/doc/assets/less/site/bootstrap/type.less
+++ b/src/doc/assets/less/site/bootstrap/type.less
@@ -1,7 +1,3 @@
-.small-caps {
-  font-family: @font-family-alt;
-}
-
 .hr {
   position: relative;
   text-align: center;

--- a/src/doc/assets/less/site/bootstrap/variables.less
+++ b/src/doc/assets/less/site/bootstrap/variables.less
@@ -49,7 +49,6 @@
 @fa-green-dark:         darken(@fa-green, 10%);
 
 @jumbotron-border:      mix(@fa-green, @fa-green-dark, 75%);
-@font-family-alt:       proxima-nova-sc, "Helvetica Neue", Helvetica, Arial, sans-serif;
 
 
 // BOOTSTRAP OVERRIDES
@@ -65,7 +64,7 @@
 
 
 // Typography
-@font-family-sans-serif:  proxima-nova, "Helvetica Neue", Helvetica, Arial, sans-serif;
+@font-family-sans-serif:  -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 @font-family-serif:       museo-slab, Georgia, "Times New Roman", Times, serif;
 @headings-font-family:    @font-family-serif;
 


### PR DESCRIPTION
- Use a modern system font stack as used by Bootstrap 4.
- Replace light font weights with normal font weights, as these are easier to read.
- Remove the use of the Proxima Nova font as it's not installed on all systems. Loading it as a web font would slow down page loading, so it's probably not a good idea if it's only used rarely.

## Preview (on Linux)

### Before

![Before](https://user-images.githubusercontent.com/180032/71314167-ee70cc80-2443-11ea-803d-dabb745a8c35.png)

### After

![After](https://user-images.githubusercontent.com/180032/71314166-ed3f9f80-2443-11ea-9b30-345723a74ca1.png)

We may also want to increase the body font size slightly.
