### PR TITLE
add note about linking pull requests to issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,13 @@ Adding a new icon is a couple steps process that will require your attention and
 5. Once you are satisfied with your design and the preview of it. Add the icon name, unicode point and icon information at the bottom of the `src/icons/icons.yml` file. Look at other entries to see how it's done and to give it a proper classification.
 6. Once all this is done, commit your changes and make a pull request.
 
+Note : Please be considerate about maintainers' time and please
+[link your pull requests] to the icon request issue if it exists. You
+could use it within your commit message as well. This saves the
+maintainers extra effort in having to keep track of and close completed
+issues.
+
+[link your pull requests]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
 
 ## Suggesting icon keyword addition/removal
 


### PR DESCRIPTION
if pull request creators are considerate enough to follow this, it could
save the maintainers a lot of time in triaging issues to be closed after
they have already been merged into the icon set.

---

I have triaged [existing issues that can be closed](https://github.com/ForkAwesome/Fork-Awesome/issues/235#issuecomment-645246783) as the icon requests are already in the pack. I am going to use this one pull request to mass-close all of those issues. I hope that is okay with the maintainers. If not, feel free to edit the description to remove all the mentions.
                                                                           
- closes #111 | merged with #207                                           
- closes #203 | merged with #204
- closes #210 | merged with #211
- commit 3d167d3ca
	- closes #145 
	- closes #151 
	- closes #152 
	- closes #167 
	- closes #170 
	- closes #171 
	- closes #173 
	- closes #174 
	- closes #175 
	- closes #176 
	- closes #177 
	- closes #178 
	- closes #180 
	- closes #187 
	- closes #190 
	- closes #195 
	- closes #212 
	- closes #214 
	- closes #215 
	- closes #227 
	- closes #228 
	- closes #229 
	- closes #233 