### PR TITLE
Specificy less-plugin-clean-css dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,9 @@
   "license": "(OFL-1.1 AND MIT)",
   "dependencies": {},
   "devDependencies": {
-    "@wikimedia/less-plugin-clean-css": "^1.5.2",
+    "less-plugin-clean-css": "^1.5.1",
     "all-contributors-cli": "^6.16.0",
     "less": "^3.11.3",
-    "less-plugin-clean-css": "^1.5.1",
     "svgo": "^1.3.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "license": "(OFL-1.1 AND MIT)",
   "dependencies": {},
   "devDependencies": {
-    "less-plugin-clean-css": "^1.5.1",
     "all-contributors-cli": "^6.16.0",
     "less": "^3.11.3",
+    "less-plugin-clean-css": "less/less-plugin-clean-css#master",
     "svgo": "^1.3.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@wikimedia/less-plugin-clean-css": "^1.5.2",
     "all-contributors-cli": "^6.16.0",
     "less": "^3.11.3",
+    "less-plugin-clean-css": "^1.5.1",
     "svgo": "^1.3.2"
   },
   "engines": {


### PR DESCRIPTION
Add `less-plugin-clean-css` to `package.json`.

After a bit of digging in #311, I found out that specifying this package **allows the site to build without error!** Perhaps this functionality was earlier part of `lessc`, and then split off as a plugin? I'm not fully sure why it works, but it works :sweat_smile: 