### PR TITLE
Revert "Remove Component"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ And constructed with the following guidelines:
 
 For more information on SemVer, please visit http://semver.org.
 
+## Component
+To include as a [component](https://github.com/componentjs/component), just run
+
+    $ component install ForkAwesome/Fork-Awesome
+
+Or add
+
+    "ForkAwesome/Fork-Awesome": "*"
+
+to the `dependencies` in your `component.json`.
+
 ## Building Fork Awesome
 
 **Before you can build the project**, you must first have the following installed:

--- a/component.json
+++ b/component.json
@@ -1,0 +1,20 @@
+{
+  "name": "fork-awesome",
+  "repo": "ForkAwesome/Fork-Awesome",
+  "description": "Fork Awesome",
+  "version": "1.2.0",
+  "keywords": [],
+  "dependencies": {},
+  "development": {},
+  "license": "SIL, MIT, CC BY 3.0",
+  "styles": [
+    "css/fork-awesome.css"
+  ],
+  "fonts": [
+    "fonts/forkawesome-webfont.eot",
+    "fonts/forkawesome-webfont.svg",
+    "fonts/forkawesome-webfont.ttf",
+    "fonts/forkawesome-webfont.woff",
+    "fonts/forkawesome-webfont.woff2"
+  ]
+}


### PR DESCRIPTION
I think we were too hasty to merge #310 in that we did not consider its impact.

We have one minor release pending to be 'released'.

This is a **breaking change**. Even if a majority does not use it; there might be that one person who still uses the font via componentJS. We do not want to break their software because we pushed a breaking change in a minor release.

Yes, I am aware that componentJS is deprecated, but the registry still exists and it works. We should have waited until a major release and announced it properly before we dropped this.