### PR TITLE
suppress warnings with RUBYOPT prefix in package.json commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "node": ">=0.10.3"
   },
   "scripts": {
-    "build": "bundle exec jekyll build",
-    "dev": "bundle exec jekyll serve -w",
+    "build": "RUBYOPT='-W0' bundle exec jekyll build",
+    "dev": "RUBYOPT='-W0' bundle exec jekyll serve -w",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate"
   },


### PR DESCRIPTION
As discussed in #311, a 'temporary' supression of known ruby warnings to make building nices.

Closes #311 