### PR TITLE
update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,12 +2,12 @@
   "name": "forkawesome/fork-awesome",
   "description": "A fork of the iconic font and CSS framework",
   "keywords": ["font", "awesome", "fontawesome", "forkawesome", "icon",  "bootstrap"],
-  "homepage": "http://forkawesome.github.io/Fork-Awesome/",
+  "homepage": "https://forkaweso.me",
   "type": "component",
   "authors": [
     {
       "name": "Fork Awesome Community",
-      "homepage": "https://forkawesome.github.io"
+      "homepage": "https://forkaweso.me"
     }
   ],
   "support": {

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,6 @@
   "support": {
     "issues": "https://github.com/ForkAwesome/Fork-Awesome/issues"
   },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "1.0.x-dev"
-    }
-  },
   "license": [
       "OFL-1.1",
       "MIT"

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,5 @@
   "license": [
       "OFL-1.1",
       "MIT"
-  ],
-  "require-dev": {
-      "jekyll": "1.0.2",
-      "lessc": "1.4.2"
-  }
+  ]
 }


### PR DESCRIPTION
`composer.json` has been outdated and broken for a long time.

Changes:
- remove dated dev dependencies from composer.json
- remove 'extra' information from composer.json
- update website URL in composer.json

Fixes #248
